### PR TITLE
support for more http methods

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -39,6 +39,26 @@
       return $private.XHRConnection( 'DELETE', url, data );
     };
 
+    $public.patch = function patch (url, data) {
+      return $private.XHRConnection('PATCH', url, data);
+    };
+
+    $public.lock = function lock (url, data) {
+      return $private.XHRConnection('LOCK', url, data);
+    };
+
+    $public.unlock = function unlock (url, data) {
+      return $private.XHRConnection('UNLOCK', url, data);
+    };
+
+    $public.link = function link (url, data) {
+      return $private.XHRConnection('LINK', url, data);
+    };
+
+    $public.unlink = function unlink (url, data) {
+      return $private.XHRConnection('UNLINK', url, data);
+    };
+
     $private.XHRConnection = function XHRConnection( type, url, data ) {
       var xhr = new XMLHttpRequest();
       var contentType = 'application/x-www-form-urlencoded';


### PR DESCRIPTION
the following http methods are missing in your implementation:

- LOCK/UNLOCK: http://www.webdav.org/specs/rfc2518.html#METHOD_LOCK
- LINK/UNLINK: http://tools.ietf.org/id/draft-snell-link-method-01.html
- PATCH: http://restcookbook.com/HTTP%20Methods/patch/