### PR TITLE
json method for jsonp

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,16 @@ ajax().post('/api/users', { slug: 'john' }).always(function(response, xhr) {
 })
 ```
 
+### `json(url, function(){/* callback */})`
+
+> Get data as a JSON object as jsonp.
+
+```js
+ajax().json('/api/users', function(users){
+  console.log(users)
+})
+```
+
 ## Deprecated methods
 
 You may see the deprecated methods [here][deprecated]

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,8 +15,8 @@ module.exports = function (config) {
       'src/**/*.js',
       'node_modules/chai/chai.js',
       'test/unit/ajax.test.js',
-      'test/unit/ajax-{get,post,put,delete}.test.js',
-      'test/unit/ajax-{get,post,put,delete}-promises.test.js'
+      'test/unit/ajax-{get,post,put,delete,json}.test.js',
+      'test/unit/ajax-{get,post,put,delete,json}-promises.test.js'
     ],
 
     // list of files to exclude

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -180,6 +180,22 @@
       )
     }
 
+    $public.json = function json (url, callback) {
+      var tag = document.createElement('script')
+      tag.type = 'text/javascript'
+      var concat = url.match(/\?/) ? '&' : '?'
+      var key = Math.random().toString(36).slice(2).substring(16)
+      var callbackName = 'jsonp_callback_' + key
+      tag.src = url + concat + 'callback=' + callbackName
+      window[callbackName] = function (data) {
+        callback.call(window, data)
+        document.getElementsByTagName('head')[0].removeChild(tag)
+        tag = null
+        delete window[callbackName]
+      }
+      document.getElementsByTagName('head')[0].appendChild(tag)
+    }
+
     return $public
   }
 

--- a/test/unit/ajax-json.test.js
+++ b/test/unit/ajax-json.test.js
@@ -1,0 +1,18 @@
+;(function (should, expect, Ajax, ajax) {
+  'use strict'
+
+  describe('#AJAX - Test `json` method', function () {
+    var request
+    beforeEach(function () {
+      request = new Ajax()
+    })
+    it('Should return data about `posts`', function (done) {
+      request.get('http://jsonplaceholder.typicode.com/posts/1')
+        .done(function (response) {
+          response.userId.should.be.equal(1)
+          response.title.should.be.equal('sunt aut facere repellat provident occaecati excepturi optio reprehenderit')
+          done()
+        })
+    })
+  })
+})(window.chai.should(), window.chai.expect, window.Ajax, window.ajax)


### PR DESCRIPTION
```javascript
Ajax().json('http://jsonplaceholder.typicode.com/posts/1', function(data){
    // callback
})
```

When requesting json while avoiding cross-origin issues jsonp is the only choice. It only needs the url and callback.

I was unable to implement a test using the localhost api so I used jsonplaceholder
```
http://jsonplaceholder.typicode.com/posts/1
```

