### PR TITLE
Use global Promise

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,6 +14,7 @@ module.exports = function (config) {
     files: [
       'src/ajax.js',
       'node_modules/chai/chai.js',
+      'node_modules/es6-promise/dist/es6-promise.js',
       'test/unit/ajax.test.js',
       'test/unit/ajax-{get,post,put,delete}.test.js',
       'test/unit/ajax-{get,post,put,delete}-promises.test.js'

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "chai": "^3.5.0",
     "concurrently": "^2.1.0",
     "cors": "^2.7.1",
+    "es6-promise": "^3.2.1",
     "express": "^4.13.4",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.0",

--- a/test/unit/ajax-delete-promises.test.js
+++ b/test/unit/ajax-delete-promises.test.js
@@ -11,9 +11,5 @@
     it('Should `delete` method return `catch` method', function () {
       expect(deleteRequest).to.have.property('catch')
     })
-
-    it('Should `delete` method return `always` method', function () {
-      expect(deleteRequest).to.have.property('always')
-    })
   })
 })(window.chai.expect, window.ajax)

--- a/test/unit/ajax-get-promises.test.js
+++ b/test/unit/ajax-get-promises.test.js
@@ -11,9 +11,5 @@
     it('Should `get` method return `catch` method', function () {
       expect(getRequest).to.have.property('catch')
     })
-
-    it('Should `get` method return `always` method', function () {
-      expect(getRequest).to.have.property('always')
-    })
   })
 })(window.chai.expect, window.ajax)

--- a/test/unit/ajax-get.test.js
+++ b/test/unit/ajax-get.test.js
@@ -6,45 +6,27 @@
 
     it('Should return an object (users list)', function (done) {
       request.get('/users').then(function (response) {
-        expect(response).to.be.an('object')
+        expect(response.data).to.be.an('object')
         done()
       })
+      .catch(function (err){ console.log(err)})
     })
 
     it('Should return data about `paulo`', function (done) {
       request.get('/user/paulo')
         .then(function (response) {
-          expect(response.name).to.be.equal('Paulo Torres')
+          expect(response.data.name).to.be.equal('Paulo Torres')
           done()
         })
     })
 
     it('Should return 404 error', function (done) {
       request.get('/something')
-        .catch(function (response, xhr) {
-          expect(xhr.status).to.be.equal(404)
+        .catch(function (response) {
+          expect(response.xhr.status).to.be.equal(404)
           done()
         })
     })
-
-    it('Should return 404 error on `always` promise', function (done) {
-      request.get('/something')
-        .always(function (response, xhr) {
-          expect(xhr.status).to.be.equal(404)
-          done()
-        })
-    })
-
-    it('Should return the same result on both promises `done` and `always`',
-      function (done) {
-        function requestResponse (response, xhr) {
-          expect(response).to.be.an('object')
-          done()
-        }
-        ajax().get('http://127.0.0.1:3000/api/users')
-          .then(requestResponse)
-          .always(requestResponse)
-      })
 
     it('Should accept headers', function (done) {
       var request = ajax({
@@ -52,7 +34,7 @@
       })
       request.get('http://localhost:3000/api/users')
         .then(function (response) {
-          expect(response).to.be.an('object')
+          expect(response.data).to.be.an('object')
           done()
         })
     })
@@ -64,7 +46,7 @@
       })
 
       request.then(function (response) {
-        expect(response).to.be.an('object')
+        expect(response.data).to.be.an('object')
         done()
       })
     })

--- a/test/unit/ajax-post-promises.test.js
+++ b/test/unit/ajax-post-promises.test.js
@@ -11,9 +11,5 @@
     it('Should `post` method return `catch` method', function () {
       expect(postRequest).to.have.property('catch')
     })
-
-    it('Should `post` method return `always` method', function () {
-      expect(postRequest).to.have.property('always')
-    })
   })
 })(window.chai.expect, window.ajax)

--- a/test/unit/ajax-post.test.js
+++ b/test/unit/ajax-post.test.js
@@ -7,7 +7,7 @@
     it('Should return an object', function (done) {
       request.post('/user/joao')
         .then(function (response) {
-          expect(response).to.be.an('object')
+          expect(response.data).to.be.an('object')
           done()
         })
     })
@@ -15,7 +15,7 @@
     it('Should return data about `joao`', function (done) {
       request.post('/user', { slug: 'joao' })
         .then(function (response) {
-          expect(response.name).to.be.equal('João da Silva')
+          expect(response.data.name).to.be.equal('João da Silva')
           done()
         })
     })
@@ -24,15 +24,15 @@
       var data = { slug: 'joao', lastname: 'other' }
       request.post('/user', data)
         .then(function (response) {
-          expect(response.name).to.be.equal('João da Silva')
+          expect(response.data.name).to.be.equal('João da Silva')
           done()
         })
     })
 
     it("Should return error 404 when user doesn't exist", function (done) {
       request.post('/user', { slug: 'alberto' })
-        .catch(function (response, xhr) {
-          expect(xhr.status).to.be.equal(404)
+        .catch(function (response) {
+          expect(response.xhr.status).to.be.equal(404)
           done()
         })
     })
@@ -44,8 +44,8 @@
         headers: { 'content-type': null }
       })
       request.post('http://localhost:3000/api/getheader', file)
-        .then(function (response, xhr) {
-          expect(response.header).to.match(/^multipart\/form-data/)
+        .then(function (response) {
+          expect(response.data.header).to.match(/^multipart\/form-data/)
           done()
         })
     })

--- a/test/unit/ajax-put-promises.test.js
+++ b/test/unit/ajax-put-promises.test.js
@@ -11,9 +11,5 @@
     it('Should `put` method return `catch` method', function () {
       expect(putRequest).to.have.property('catch')
     })
-
-    it('Should `put` method return `always` method', function () {
-      expect(putRequest).to.have.property('always')
-    })
   })
 })(window.chai.expect, window.ajax)


### PR DESCRIPTION
Expect a globally available Promise either natively available or
provided through a polyfill.

`.always` is removed from the promise api as it's non-standard. Related
tests are removed.

Given that `resolve` and `reject` only accept one argument, responses
are passed through as `{data: parsedResponse, xhr: xhr}`. Errors
provided to `reject` have the same interface.

Added `es6-promise` as a devDependency because PhantomJS doesn't have
native promises yet.

Opening this as a discussion point for #20.
