### PR TITLE
Fix browser logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,9 +264,9 @@ Check [CONTRIBUTING.md][contributing-url]
 
 ## Browser compatibility
 
-![Chrome][chrome-logo] | ![Firefox][firefox-logo] | ![IE][ie-logo] | ![Edge][edge-logo] | ![Opera][opera-logo] | ![Safari][safari-ios-logo]
----                    | ---                      | ---            | ---                | ---                  | ---
-Latest ✔               | Latest ✔                 | 9+ ✔           | Latest ✔           | Latest ✔             | 3.2+ ✔
+| ![Chrome][chrome-logo] | ![Firefox][firefox-logo] | ![IE][ie-logo] | ![Edge][edge-logo] | ![Opera][opera-logo] | ![Safari][safari-logo] |
+| ---------------------- | ------------------------ | -------------- | ------------------ | -------------------- | ---------------------- |
+| Latest ✔               | Latest ✔                 | 9+ ✔           | Latest ✔           | Latest ✔             | 3.2+ ✔                 |
 
 ## License
 
@@ -285,9 +285,9 @@ Latest ✔               | Latest ✔                 | 9+ ✔           | Lates
 [contributing-image]: https://img.shields.io/badge/fdaciuk%2Fajax-CONTRIBUTE-orange.svg?style=flat-square
 [contributing-url]: CONTRIBUTING.md
 [deprecated]: deprecated.md
-[chrome-logo]: https://rawgit.com/alrra/browser-logos/master/chrome/chrome_48x48.png
-[firefox-logo]: https://rawgit.com/alrra/browser-logos/master/firefox/firefox_48x48.png
-[ie-logo]: https://rawgit.com/alrra/browser-logos/master/internet-explorer/internet-explorer_48x48.png
-[edge-logo]: https://rawgit.com/alrra/browser-logos/master/edge/edge_48x48.png
-[opera-logo]: https://rawgit.com/alrra/browser-logos/master/opera/opera_48x48.png
-[safari-ios-logo]: https://rawgit.com/alrra/browser-logos/master/safari-ios/safari-ios_48x48.png
+[chrome-logo]: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/41.2.1/chrome/chrome_48x48.png
+[firefox-logo]: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/41.2.1/firefox/firefox_48x48.png
+[ie-logo]: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/41.2.1/archive/internet-explorer_9-11/internet-explorer_9-11_48x48.png
+[edge-logo]: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/41.2.1/edge/edge_48x48.png
+[opera-logo]: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/41.2.1/opera/opera_48x48.png
+[safari-logo]: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/41.2.1/safari/safari_48x48.png


### PR DESCRIPTION
Related to #47.

I couldn't put SVGs yet because not all browsers have SVG logos on [alrra/browser-logos](https://github.com/alrra/browser-logos).

I've opened issues there to fix that.

Meanwhile we can fix the README by using the `cdnjs` link with a fixed version of the logos. This will prevent them from breaking if the repo change the location again.

Later on, the switch to SVG may happen once all the logos are available.

Feel free to reject this PR or ask for changes if needed.

Thanks.